### PR TITLE
removeChild isn't faster than innerHTML

### DIFF
--- a/src/codeflask.js
+++ b/src/codeflask.js
@@ -42,11 +42,7 @@
                 highlightCode.style.paddingLeft = '3px';
             }
 
-            //Faster than innerHTML = ''
-            while(target.firstChild) {
-                target.removeChild(target.firstChild);
-            }
-
+            target.innerHTML = '';
             target.appendChild(textarea);
             target.appendChild(highlightPre);
             highlightPre.appendChild(highlightCode);


### PR DESCRIPTION
http://codepen.io/NeXTs/pen/LVodbO?editors=101
Only place where removeChild loop may be preferable is handling table
elements for ie9 and lower, as old ie's does not support to do innerHTML
for table elements.