### PR TITLE
Fix issue #17: change autocorrect behaviour

### DIFF
--- a/src/codeflask.js
+++ b/src/codeflask.js
@@ -33,6 +33,15 @@ CodeFlask.prototype.scaffold = function(target, isMultiple, opts) {
         initialCode = target.textContent,
         lang;
 
+    if(!opts.enableAutocorrect == true)
+    {
+        // disable autocorrect and spellcheck features
+        textarea.setAttribute('spellcheck', 'false');
+        textarea.setAttribute('autocapitalize', 'off');
+        textarea.setAttribute('autocomplete', 'off');
+        textarea.setAttribute('autocorrect', 'off');
+    }
+
     opts.language = this.handleLanguage(opts.language);
 
     this.defaultLanguage = target.dataset.language || opts.language || 'markup';


### PR DESCRIPTION
Fix issue by disabling the autocorrect and spellcheck features by
default. They can be re-enabled by adding enableAutocorrect: true to the
options.