### PR TITLE
Fix issue #14 - missing new lines when javascript is disabled

### DIFF
--- a/src/codeflask.css
+++ b/src/codeflask.css
@@ -49,3 +49,7 @@
     color:inherit;
     display:block;
 }
+
+.CodeFlask__is-code{
+    white-space: pre;
+}

--- a/src/codeflask.js
+++ b/src/codeflask.js
@@ -33,6 +33,15 @@ CodeFlask.prototype.scaffold = function(target, isMultiple, opts) {
         initialCode = target.textContent,
         lang;
 
+    if(!opts.enableAutocorrect == true)
+    {
+        // disable autocorrect and spellcheck features
+        textarea.setAttribute('spellcheck', 'false');
+        textarea.setAttribute('autocapitalize', 'off');
+        textarea.setAttribute('autocomplete', 'off');
+        textarea.setAttribute('autocorrect', 'off');
+    }
+
     opts.language = this.handleLanguage(opts.language);
 
     this.defaultLanguage = target.dataset.language || opts.language || 'markup';


### PR DESCRIPTION
This adds the .CodeFlask__is-code class which keeps the newlines even when they have not been specifically declared (as proposed by @kazzkiq )