### PR TITLE
Fixed iOS scrolling issue

### DIFF
--- a/src/codeflask.css
+++ b/src/codeflask.css
@@ -31,6 +31,7 @@
     z-index:1;
     height:100%;
     -webkit-overflow-scrolling: touch;
+    -webkit-text-fill-color: transparent;
 }
 
 .CodeFlask__pre{


### PR DESCRIPTION
Fixed iOS issue that was caused by scroll bouncing and delay. The textfield’s text is now transparent but the cursor is still visible.