### PR TITLE
Fix cursor position when "\t" is used as indentation

### DIFF
--- a/src/codeflask.css
+++ b/src/codeflask.css
@@ -8,7 +8,7 @@
     box-sizing:border-box;
     position:absolute;
     top:0;
-	left:0;
+    left:0;
     width:100%;
     padding:1rem !important;
     border:none;
@@ -32,6 +32,7 @@
     height:100%;
     -webkit-overflow-scrolling: touch;
     -webkit-text-fill-color: transparent;
+    tab-size: 4;
 }
 
 .CodeFlask__pre{


### PR DESCRIPTION
Before, for "\t", code was shown as 4 size tab, but cursor as 8 size tab, causing a bug. The cursor position was not the location code was inserted while typing.