### PR TITLE
Add Custom Element wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It was made as an attempt to create a leaner editor for simple purposes. Just a 
 
 If you want a robust web code editor you can check projects that aim that big, such as CodeMirror.
 
+CodeFlask.js is usable as a Web Component (Custom Elements v1 / Shadow DOM v1).
+
 ## Install
 
 
@@ -81,6 +83,46 @@ flask.run('#my-code-wrapper', { language: 'javascript', lineNumbers: true })
 ```
 
  It is important to remember that CodeFlask.js checks primarily for `data-language` attribute, then for the function call version. If none of those are declared, the editor will render in **HTML syntax**;
+
+#### Usage as a Web Component
+
+Alternatively, you can use the included Web Component wrapper, which uses [Custom Elements v1](https://developers.google.com/web/fundamentals/getting-started/primers/customelements) and [Shadow DOM v1](https://developers.google.com/web/fundamentals/getting-started/primers/shadowdom) to provide the editor as a DOM element.
+
+The element picks up the text provided inside of the element's body, responds to changing the `language` attribute and property, and lets you customize the highlighting colors via CSS Custom Properties:
+
+```html
+<script src="bower_components/prism/prism.js"></script>
+<script src="bower_components/prism/components/prism-markdown.js"></script>
+<link rel="import" href="bower_components/codeflask-editor/src/codeflask-editor.html">
+<style>
+  codeflask-editor {
+    height: 90vh;
+    font-family: cursive;
+    --color-punctuation: lime;
+    --color-important: red;
+  }
+</style>
+<codeflask-editor language="markdown">
+# hello world
+Initial text here.
+</codeflask-editor>
+<script>
+  document.querySelector('codeflask-editor').addEventListener('value-changed', console.log)
+</script>
+```
+
+The element emits a `value-changed` event on content changes, which makes it compatible with [Polymer](https://www.polymer-project.org)'s two-way data binding:
+
+```html
+<codeflask-editor language="{{lang}}" value="{{code}}"></codeflask-editor>
+```
+
+Instead of the HTML Import, you can include the scripts directly:
+
+```html
+<script src="codeflask.js"></script>
+<script src="codeflask-editor.js"></script>
+```
 
 #### Listening for changes and updating your editor
 

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "Claudio Holanda"
   ],
   "dependencies": {
-    "prism": "~1.0.1"
+    "prism": "*"
   },
   "description": "A micro code-editor for awesome web pages.",
   "main": [
@@ -20,7 +20,8 @@
   "keywords": [
     "code-editor",
     "plugin",
-    "syntax-highlight"
+    "syntax-highlight",
+    "web-components"
   ],
   "license": "MIT",
   "ignore": [

--- a/src/codeflask-editor.html
+++ b/src/codeflask-editor.html
@@ -1,0 +1,2 @@
+<script src="codeflask.js"></script>
+<script src="codeflask-editor.js"></script>

--- a/src/codeflask-editor.js
+++ b/src/codeflask-editor.js
@@ -1,0 +1,209 @@
+const codeFlaskOwnerDoc = document.currentScript.ownerDocument
+
+class CodeflaskEditor extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        const style = document.createElement('style');
+        style.appendChild(document.createTextNode(`
+            :host {
+                position:relative;
+                overflow:hidden;
+                display:block;
+                contain:content;
+                min-height:4em;
+                font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+                --color-comment: slategray;
+                --color-punctuation: #999;
+                --color-property: #905;
+                --color-selector: #690;
+                --color-operator: #a67f59;
+                --color-keyword: #07a;
+                --color-function: #DD4A68;
+                --color-variable: #e90;
+            }
+
+            :host > div {
+                position:absolute;
+                overflow:hidden;
+                top:0;
+                right:0;
+                bottom:0;
+                left:0;
+            }
+
+            .CodeFlask__textarea,
+            .CodeFlask__pre {
+                box-sizing:border-box;
+                position:absolute;
+                top:0;
+                left:0;
+                right:0;
+                width:100%;
+                padding:1rem !important;
+                border:none;
+                font-family:inherit;
+                font-size:inherit;
+                background:transparent;
+                white-space:pre-wrap !important;
+                line-height:1.5em;
+                word-wrap: break-word;
+            }
+
+            .CodeFlask__textarea{
+                border:none;
+                background:transparent;
+                outline:none;
+                resize:none;
+                opacity:0.4;
+                color:#000;
+                margin:0;
+                z-index:1;
+                height:100%;
+                -webkit-overflow-scrolling: touch;
+                -webkit-text-fill-color: transparent;
+                tab-size: 4;
+            }
+
+            .CodeFlask__pre{
+                z-index:2;
+                pointer-events:none;
+                overflow-y:auto;
+                margin:0;
+                min-height:100%;
+                margin:0 !important;
+                background:transparent !important;
+            }
+
+            .CodeFlask__code{
+                font-size:inherit;
+                font-family:inherit;
+                color:inherit;
+                display:block;
+            }
+
+            .CodeFlask__is-code {
+                white-space: pre;
+            }
+
+            .token.comment { color: var(--color-comment); }
+            .token.prolog  { color: var(--color-prolog, var(--color-comment)); }
+            .token.doctype { color: var(--color-doctype, var(--color-comment)); }
+            .token.cdata   { color: var(--color-cdata, var(--color-comment)); }
+
+            .token.punctuation { color: var(--color-punctuation); }
+
+            .namespace { opacity: .7; }
+
+            .token.property { color: var(--color-property); }
+            .token.tag      { color: var(--color-tag, var(--color-property)); }
+            .token.boolean  { color: var(--color-boolean, var(--color-property)); }
+            .token.number   { color: var(--color-number, var(--color-property)); }
+            .token.constant { color: var(--color-constant, var(--color-property)); }
+            .token.symbol   { color: var(--color-symbol, var(--color-property)); }
+            .token.deleted  { color: var(--color-deleted, var(--color-property)); }
+
+            .token.selector  { color: var(--color-selector); }
+            .token.attr-name { color: var(--color-attr-name, var(--color-selector)); }
+            .token.string    { color: var(--color-string, var(--color-selector)); }
+            .token.char      { color: var(--color-char, var(--color-selector)); }
+            .token.builtin   { color: var(--color-builtin, var(--color-selector)); }
+            .token.inserted  { color: var(--color-inserted, var(--color-selector)); }
+
+            .token.operator { color: var(--color-selector); }
+            .token.entity   { color: var(--color-entity, var(--color-selector)); }
+            .token.url      { color: var(--color-url, var(--color-selector)); }
+            .language-css .token.string { color: var(--color-css-string, var(--color-selector)); }
+            .style .token.string        { color: var(--color-css-string, var(--color-selector)); }
+
+            .token.keyword    { color: var(--color-keyword); }
+            .token.atrule     { color: var(--color-atrule, var(--color-keyword)); }
+            .token.attr-value { color: var(--color-attr-value, var(--color-keyword)); }
+
+            .token.function { color: var(--color-function); }
+
+            .token.variable  { color: var(--color-variable); }
+            .token.regex     { color: var(--color-regex, var(--color-variable)); }
+            .token.important { color: var(--color-important, var(--color-variable)); }
+
+            .token.important, .token.bold { font-weight: bold; }
+            .token.italic { font-style: italic; }
+            .token.entity { cursor: help; }
+        `))
+        this.shadowRoot.appendChild(style);
+        this.editorElement = document.createElement('div');
+        this.shadowRoot.appendChild(this.editorElement);
+        this.flask = new CodeFlask;
+        this.flask.docroot = this.shadowRoot;
+        this.flask.run(this.editorElement, {
+            language: this.getAttribute('language') || 'markup',
+            rtl: this.dir === 'rtl',
+        });
+        this.flask.onUpdate(code => {
+            this.dispatchEvent(new CustomEvent('value-changed'));
+        })
+        this.value = this.getAttribute('value');
+        if (!this.value) {
+            this.initElement = document.createElement('div');
+            this.shadowRoot.appendChild(this.initElement);
+            this.initSlot = document.createElement('slot');
+            this.initElement.appendChild(this.initSlot);
+        }
+    }
+
+    connectedCallback() {
+        if (this.initSlot) {
+            let value = '';
+            for (const node of this.initSlot.assignedNodes()) {
+                value += node.outerHTML || node.textContent;
+            }
+            this.initElement.removeChild(this.initSlot);
+            this.shadowRoot.removeChild(this.initElement);
+            if (value.length > 0) {
+                this.value = value
+            }
+        }
+    }
+
+    get value() {
+        return this.flask.textarea && this.flask.textarea.value;
+    }
+
+    set value(val) {
+        this.removeAttribute('value');
+        return this.flask.update(val);
+    }
+
+    get language() {
+        return this.flask.defaultLanguage;
+    }
+
+    set language(val) {
+        if (!val) {
+            return;
+        }
+        this.flask.defaultLanguage = this.flask.handleLanguage(val);
+        for (const klass of this.flask.highlightCode.classList) {
+            if (klass.startsWith('language-')) {
+                this.flask.highlightCode.classList.remove(klass);
+            }
+        }
+        this.flask.highlightCode.classList.add('language-' + this.flask.defaultLanguage);
+        this.flask.highlight(this.flask.highlightCode);
+        this.dispatchEvent(new CustomEvent('language-changed'));
+    }
+
+    get dir() {
+        return this.getAttribute('dir') || 'ltr';
+    }
+
+    static get observedAttributes() {
+        return ['language', 'value'];
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+        this[name] = newValue;
+    }
+}
+
+customElements.define('codeflask-editor', CodeflaskEditor);

--- a/src/codeflask.js
+++ b/src/codeflask.js
@@ -1,9 +1,14 @@
 function CodeFlask(indent) {
-  this.indent = indent || "    ";
+    this.indent = indent || "    ";
+    this.docroot = document;
+}
+
+CodeFlask.isString = function(x) {
+    return Object.prototype.toString.call(x) === "[object String]";
 }
 
 CodeFlask.prototype.run = function(selector, opts) {
-    var target = document.querySelectorAll(selector);
+    var target = CodeFlask.isString(selector) ? this.docroot.querySelectorAll(selector) : [selector];
 
     if(target.length > 1) {
         throw 'CodeFlask.js ERROR: run() expects only one element, ' +
@@ -18,7 +23,7 @@ CodeFlask.prototype.runAll = function(selector, opts) {
     this.update = null;
     this.onUpdate = null;
 
-    var target = document.querySelectorAll(selector);
+    var target = CodeFlask.isString(selector) ? this.docroot.querySelectorAll(selector) : selector;
 
     var i;
     for(i=0; i < target.length; i++) {
@@ -28,7 +33,7 @@ CodeFlask.prototype.runAll = function(selector, opts) {
     // Add the MutationObserver below for each one of the textAreas so we can listen
     // to when the dir attribute has been changed and also return the placeholder
     // dir attribute with it so it reflects the changes made to the textarea.
-    var textAreas = document.getElementsByClassName("CodeFlask__textarea");
+    var textAreas = this.docroot.getElementsByClassName("CodeFlask__textarea");
     for(var i = 0; i < textAreas.length; i++)
     {
       window.MutationObserver = window.MutationObserver
@@ -38,7 +43,7 @@ CodeFlask.prototype.runAll = function(selector, opts) {
       var target = textAreas[i];
 
       observer = new MutationObserver(function(mutation) {
-        var textAreas = document.getElementsByClassName("CodeFlask__textarea");
+        var textAreas = this.docroot.getElementsByClassName("CodeFlask__textarea");
           for(var i = 0; i < textAreas.length; i++)
            {
             // If the text direction values are different set them
@@ -119,7 +124,7 @@ CodeFlask.prototype.scaffold = function(target, isMultiple, opts) {
     textarea.value = initialCode;
     this.renderOutput(highlightCode, textarea);
 
-    Prism.highlightAll();
+    this.highlight(highlightCode);
 
     this.handleInput(textarea, highlightCode, highlightPre);
     this.handleScroll(textarea, highlightPre);
@@ -148,7 +153,7 @@ CodeFlask.prototype.handleInput = function(textarea, highlightCode, highlightPre
 
         self.renderOutput(highlightCode, input);
 
-        Prism.highlightAll();
+        self.highlight(highlightCode);
     });
 
     textarea.addEventListener('keydown', function(e) {
@@ -182,7 +187,7 @@ CodeFlask.prototype.handleInput = function(textarea, highlightCode, highlightPre
             highlightCode.innerHTML = input.value.replace(/&/g, "&amp;")
                 .replace(/</g, "&lt;")
                 .replace(/>/g, "&gt;") + "\n";
-            Prism.highlightAll();
+            self.highlight(highlightCode);
         }
     });
 }
@@ -227,8 +232,12 @@ CodeFlask.prototype.update = function(string) {
 
     this.textarea.value = string;
     this.renderOutput(this.highlightCode, this.textarea);
-    Prism.highlightAll();
+    this.highlight(this.highlightCode);
 
     evt.initEvent("input", false, true);
     this.textarea.dispatchEvent(evt);
+}
+
+CodeFlask.prototype.highlight = function(highlightCode) {
+    Prism.highlightElement(highlightCode);
 }


### PR DESCRIPTION
Hi. Thanks for your work, it's the simplest editor I've seen.

I'm working on a Polymer 2 app, needed a lightweight code editor element… so here it is.
I see Web Components were already suggested in #2 :)

Yeah the style is inlined right there in the class. Two reasons for that — first, you can't just put a `<link rel=stylesheet href=codeflask.css>` into Shadow DOM because the relative URL won't resolve from the current HTML Import, it'll resolve against the base document. Second, when the style is in the JS, it is easy to use the component without HTML Imports at all.

<img width="653" alt="screenshot" src="https://cloud.githubusercontent.com/assets/208340/26270071/717896b2-3d01-11e7-9911-cabb8af541ff.png">
